### PR TITLE
fixed scp service

### DIFF
--- a/plugins/plugin-artik-server/src/main/java/org/eclipse/che/plugin/machine/artik/scp/PushToDeviceService.java
+++ b/plugins/plugin-artik-server/src/main/java/org/eclipse/che/plugin/machine/artik/scp/PushToDeviceService.java
@@ -57,7 +57,6 @@ import java.util.stream.Collectors;
 @Singleton
 @Beta
 public class PushToDeviceService extends Service {
-    private static final String DEFAULT_SSH_PORT          = "22";
     private static final String DEFAULT_PROJECTS_LOCATION = "/projects";
 
     @Inject
@@ -146,8 +145,10 @@ public class PushToDeviceService extends Service {
 
         CommandLine commandLine = new CommandLine("sshpass -p", password);
         commandLine.add("scp -o StrictHostKeyChecking=no")
+                   .add("-P")
+                   .add(port)
                    .add(Files.isDirectory(Paths.get(filePath)) ? "-r " : "", filePath)
-                   .add(username + '@' + host + ':' + (port.equals(DEFAULT_SSH_PORT) ? "" : port + ':') + targetPath);
+                   .add(username + '@' + host + ':' + targetPath);
         return commandLine;
     }
 


### PR DESCRIPTION
@vparfonov @garagatyi @ashumilova please review. We had a bug in scp service - used the wrong syntax. It worked when ssh port was 22. However, when this port is not 22, `-P` parameter should be used. Let's use it by default since we get the port from device recipe anyway and this way we'll be always using the right port.