### PR TITLE
CHE-956 remove dependency on che-jdt-ext-machine

### DIFF
--- a/assembly/assembly-wsagent-war/pom.xml
+++ b/assembly/assembly-wsagent-war/pom.xml
@@ -101,11 +101,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
-            <artifactId>che-jdt-ext-machine</artifactId>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-cpp-lang-server</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
According to https://github.com/eclipse/che/pull/1306