### PR TITLE
Add default logs commands for Artik stack

### DIFF
--- a/assembly/assembly-main/src/assembly/stacks/stacks.json
+++ b/assembly/assembly-main/src/assembly/stacks/stacks.json
@@ -4,6 +4,13 @@
     "creator": "ide",
     "name": "Artik",
     "description": "Artik Development Stack",
+    "commands": [
+      {
+        "commandLine": "journalctl --since today",
+        "name": "tail logs",
+        "type": "custom"
+      }
+    ],
     "scope": "general",
     "tags": [
       "Fedora 23",

--- a/assembly/assembly-main/src/assembly/templates/samples.json
+++ b/assembly/assembly-main/src/assembly/templates/samples.json
@@ -35,7 +35,7 @@
     "problems": [],
     "source": {
       "type": "git",
-      "location": "https://github.com/che-samples/artik-http-test.git",
+      "location": "https://github.com/che-samples/artik-http-test",
       "parameters": {}
     },
     "commands": [


### PR DESCRIPTION
This was a user will get journalctl logs. The command can be then changed to tail any log file.