### PR TITLE
Add spi build command

### DIFF
--- a/assembly/assembly-main/src/assembly/templates/samples.json
+++ b/assembly/assembly-main/src/assembly/templates/samples.json
@@ -36,7 +36,9 @@
     "source": {
       "type": "git",
       "location": "https://github.com/artik-iot/artik-sdk-examples",
-      "parameters": {}
+      "parameters": {
+        "branch": "ARTIK_SDK_V0.13"
+      }
     },
     "commands": [
       {
@@ -115,6 +117,14 @@
         "name": "serial-build",
         "type": "custom",
         "commandLine": "echo 'Compiling...' && cd ${current.project.path}/serial && $CC -lartik-sdk-base -I$CPATH/systemio -I$CPATH/base -lpthread -g artik_serial_test.c && echo 'Compilation succeeded. You may need to refresh project tree to find compiled binary.'",
+        "attributes": {
+          "previewUrl": ""
+        }
+      },
+      {
+        "name": "spi-build",
+        "type": "custom",
+        "commandLine": "echo 'Compiling...' && cd ${current.project.path}/spi && $CC -lartik-sdk-base -I$CPATH/systemio -I$CPATH/base -lpthread -g artik_spi_test.c && echo 'Compilation succeeded. You may need to refresh project tree to find compiled binary.'",
         "attributes": {
           "previewUrl": ""
         }

--- a/plugins/plugin-artik-ide/src/main/java/org/eclipse/che/plugin/artik/ide/updatesdk/UpdateSDKViewImpl.ui.xml
+++ b/plugins/plugin-artik-ide/src/main/java/org/eclipse/che/plugin/artik/ide/updatesdk/UpdateSDKViewImpl.ui.xml
@@ -45,7 +45,7 @@
                 <c:CellTable width="100%" ui:field="targetsTable" focus="false"/>
             </g:ScrollPanel>
         </g:center>
-        <g:south size="120">
+        <g:south size="130">
             <g:FlowPanel styleName="{style.bottom-panel}">
                 <g:Label addStyleNames="{style.box-label}" text="{localizationConstants.updateSDKViewLabelSelectVersionTitle}"/>
                 <che:CustomListBox ui:field="versionsBox" debugId="window-artik-updateSDK-availableVersion" addStyleNames="{style.box}"/>


### PR DESCRIPTION
0.13 SDK is out. Add command to build spi sample app. Use ARTIK_SDK_V0.13 tag