### PR TITLE
CHE-2286: disable menu items until the workspace is not running

### DIFF
--- a/plugins/plugin-artik-ide/src/main/java/org/eclipse/che/plugin/artik/ide/apidocs/ShowDocsAction.java
+++ b/plugins/plugin-artik-ide/src/main/java/org/eclipse/che/plugin/artik/ide/apidocs/ShowDocsAction.java
@@ -15,7 +15,7 @@ import com.google.gwt.user.client.Window;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
-import org.eclipse.che.ide.api.action.Action;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.plugin.artik.ide.ArtikLocalizationConstant;
 
@@ -25,13 +25,13 @@ import org.eclipse.che.plugin.artik.ide.ArtikLocalizationConstant;
  * @author Artem Zatsarynnyi
  */
 @Singleton
-public class ShowDocsAction extends Action {
+public class ShowDocsAction extends AbstractPerspectiveAction {
 
     private final DocsPartPresenter docsPartPresenter;
 
     @Inject
     public ShowDocsAction(DocsPartPresenter docsPartPresenter, ArtikLocalizationConstant localizationConstants) {
-        super(localizationConstants.showApiDocActionTitle(), localizationConstants.showApiDocActionDescription());
+        super(null, localizationConstants.showApiDocActionTitle(), localizationConstants.showApiDocActionDescription());
 
         this.docsPartPresenter = docsPartPresenter;
     }
@@ -39,5 +39,10 @@ public class ShowDocsAction extends Action {
     @Override
     public void actionPerformed(ActionEvent e) {
         Window.open(docsPartPresenter.getDocURL(), "_blank", null);
+    }
+
+    @Override
+    public void updateInPerspective(ActionEvent e) {
+        e.getPresentation().setEnabledAndVisible(true);
     }
 }

--- a/plugins/plugin-artik-ide/src/main/java/org/eclipse/che/plugin/artik/ide/scp/action/PushToDeviceAction.java
+++ b/plugins/plugin-artik-ide/src/main/java/org/eclipse/che/plugin/artik/ide/scp/action/PushToDeviceAction.java
@@ -14,7 +14,7 @@ package org.eclipse.che.plugin.artik.ide.scp.action;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
-import org.eclipse.che.ide.api.action.Action;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.selection.Selection;
 import org.eclipse.che.ide.api.selection.SelectionAgent;
@@ -28,7 +28,7 @@ import org.eclipse.che.plugin.artik.ide.scp.PushToDeviceManager;
  *
  * @author Dmitry Shnurenko
  */
-public class PushToDeviceAction extends Action {
+public class PushToDeviceAction extends AbstractPerspectiveAction {
 
     private final SelectionAgent      selectionAgent;
     private final PushToDeviceManager scpManager;
@@ -39,7 +39,7 @@ public class PushToDeviceAction extends Action {
                               ArtikLocalizationConstant locale,
                               PushToDeviceManager scpManager,
                               @Assisted String machineName) {
-        super(machineName, locale.pushToDeviceDescription(), null, null);
+        super(null, machineName, locale.pushToDeviceDescription(), null, null);
 
         this.selectionAgent = selectionAgent;
         this.machineName = machineName;
@@ -64,5 +64,10 @@ public class PushToDeviceAction extends Action {
         }
 
         return "";
+    }
+
+    @Override
+    public void updateInPerspective(ActionEvent e) {
+        e.getPresentation().setEnabledAndVisible(true);
     }
 }

--- a/plugins/plugin-artik-ide/src/main/java/org/eclipse/che/plugin/artik/ide/updatesdk/UpdateSDKAction.java
+++ b/plugins/plugin-artik-ide/src/main/java/org/eclipse/che/plugin/artik/ide/updatesdk/UpdateSDKAction.java
@@ -14,7 +14,7 @@ package org.eclipse.che.plugin.artik.ide.updatesdk;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
-import org.eclipse.che.ide.api.action.Action;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.plugin.artik.ide.ArtikLocalizationConstant;
 
@@ -24,18 +24,23 @@ import org.eclipse.che.plugin.artik.ide.ArtikLocalizationConstant;
  * @author Artem Zatsarynnyi
  */
 @Singleton
-public class UpdateSDKAction extends Action {
+public class UpdateSDKAction extends AbstractPerspectiveAction {
 
     private final UpdateSDKPresenter presenter;
 
     @Inject
     public UpdateSDKAction(UpdateSDKPresenter presenter, ArtikLocalizationConstant localizationConstants) {
-        super(localizationConstants.updateSDKActionTitle(), localizationConstants.updateSDKActionDescription());
+        super(null, localizationConstants.updateSDKActionTitle(), localizationConstants.updateSDKActionDescription());
         this.presenter = presenter;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
         presenter.show();
+    }
+
+    @Override
+    public void updateInPerspective(ActionEvent e) {
+        e.getPresentation().setEnabledAndVisible(true);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <url>https://github.com/codenvy/artik-ide</url>
     </scm>
     <properties>
-        <che.version>4.8.0-artik</che.version>
+        <che.version>4.8.1-artik-SNAPSHOT</che.version>
         <dto-generator-out-directory>${project.build.directory}/generated-sources/dto/</dto-generator-out-directory>
         <license_contributor>Codenvy, S.A. - Initial implementation</license_contributor>
         <license_contributor2>Samsung Electronics Co., Ltd. - Initial implementation</license_contributor2>


### PR DESCRIPTION
### What does this PR do?
Disable menu items until the workspace is not running

### What issues does this PR fix or reference?
#2286
![selection_005](https://cloud.githubusercontent.com/assets/6310786/18589225/5c72a7f2-7c32-11e6-876d-4d6dcf48386f.png)


@ashumilova, @vparfonov please review

Signed-off-by: Oleksii Orel <oorel@codenvy.com>