### PR TITLE
Added port parameter to rsync.sh command builder

### DIFF
--- a/plugins/plugin-artik-server/src/main/java/org/eclipse/che/plugin/machine/artik/replication/shell/CommandBuilder.java
+++ b/plugins/plugin-artik-server/src/main/java/org/eclipse/che/plugin/machine/artik/replication/shell/CommandBuilder.java
@@ -45,7 +45,8 @@ class CommandBuilder {
                                 .add(ctx.getPassword())
                                 .add(ctx.getSourcePath())
                                 .add(ctx.getHost())
-                                .add(ctx.getTargetPath());
+                                .add(ctx.getTargetPath())
+                                .add(ctx.getPort());
     }
 
     /**

--- a/plugins/plugin-artik-server/src/test/java/org/eclipse/che/plugin/machine/artik/replication/shell/CommandBuilderTest.java
+++ b/plugins/plugin-artik-server/src/test/java/org/eclipse/che/plugin/machine/artik/replication/shell/CommandBuilderTest.java
@@ -42,7 +42,7 @@ public class CommandBuilderTest {
     private static final String SCP_COMMAND_LINE   = format("sshpass -p %s scp -P %s -o StrictHostKeyChecking=no -r %s %s@%s:%s",
                                                             PASSWORD, PORT, SOURCE, USERNAME, HOST, TARGET);
 
-    private static final String RSYNC_COMMAND_LINE   = format("rsync.sh %s %s %s %s %s", USERNAME, PASSWORD, SOURCE, HOST, TARGET);
+    private static final String RSYNC_COMMAND_LINE   = format("rsync.sh %s %s %s %s %s %s", USERNAME, PASSWORD, SOURCE, HOST, TARGET, PORT);
 
     @Mock
     private ScpCommandContext   scpCommandContext;

--- a/plugins/plugin-artik-server/src/test/java/org/eclipse/che/plugin/machine/artik/replication/shell/ShellCommandManagerTest.java
+++ b/plugins/plugin-artik-server/src/test/java/org/eclipse/che/plugin/machine/artik/replication/shell/ShellCommandManagerTest.java
@@ -52,7 +52,7 @@ public class ShellCommandManagerTest {
     private static final String SCP_COMMAND_LINE = format("sshpass -p %s scp -P %s -o StrictHostKeyChecking=no  %s %s@%s:%s%s",
                                                           PASSWORD, PORT, SOURCE, USERNAME, HOST, REPLICATION, TARGET);
 
-    private static final String RSYNC_COMMAND_LINE = format("rsync.sh %s %s %s %s %s", USERNAME, PASSWORD, SOURCE, HOST, REPLICATION);
+    private static final String RSYNC_COMMAND_LINE = format("rsync.sh %s %s %s %s %s %s", USERNAME, PASSWORD, SOURCE, HOST, REPLICATION, PORT);
     @Mock
     private JsonValueHelper      jsonValueHelper;
     @Mock


### PR DESCRIPTION
Added port parameter to `rsync.sh` script command builder according to https://github.com/codenvy/artik-ide/issues/161 issue.

Related PR: https://github.com/codenvy/dockerfiles/pull/52