### PR TITLE
Follow cli refactoring performed in che cli

### DIFF
--- a/dockerfiles/cli/scripts/cli.sh
+++ b/dockerfiles/cli/scripts/cli.sh
@@ -5,11 +5,17 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #
-cli_pre_init() {
+
+post_init() {
   GLOBAL_HOST_IP=${GLOBAL_HOST_IP:=$(docker_run --net host eclipse/che-ip:nightly)}
   DEFAULT_ARTIK_HOST=$GLOBAL_HOST_IP
   ARTIK_HOST=${ARTIK_HOST:-${DEFAULT_ARTIK_HOST}}
-  ARTIK_PORT=8080
+  DEFAULT_ARTIK_PORT=8080
+  ARTIK_PORT=${ARTIK_PORT:-${DEFAULT_ARTIK_PORT}}
+  CHE_PORT=${ARTIK_PORT}
+  CHE_MIN_RAM=1.5
+  CHE_MIN_DISK=100
+
 }
 
 # Runs puppet image to generate ${CHE_FORMAL_PRODUCT_NAME} configuration

--- a/dockerfiles/cli/scripts/entrypoint.sh
+++ b/dockerfiles/cli/scripts/entrypoint.sh
@@ -19,44 +19,16 @@ CHE_SCRIPTS_CONTAINER_SOURCE_DIR="/repo/dockerfiles/cli/scripts"
 CHE_SERVER_CONTAINER_NAME="artik"
 CHE_IMAGE_FULLNAME="codenvy/artik-cli"
 
-init_usage() {
-  USAGE="
-USAGE:
-  docker run --rm <DOCKER_PARAMETERS> ${CHE_IMAGE_FULLNAME} [COMMAND]
 
-MANDATORY DOCKER PARAMETERS:
-  -v <LOCAL_PATH>:${CHE_CONTAINER_ROOT}                Where user, instance, and log data saved
-
-OPTIONAL DOCKER PARAMETERS:
-  -e ARTIK_HOST=<YOUR_HOST>            IP address or hostname where ${CHE_MINI_PRODUCT_NAME} will serve its users
-  -e ARTIK_PORT=<YOUR_PORT>            Port where ${CHE_MINI_PRODUCT_NAME} will bind itself to
-  -v <LOCAL_PATH>:${CHE_CONTAINER_ROOT}/instance       Where instance, user, log data will be saved
-  -v <LOCAL_PATH>:${CHE_CONTAINER_ROOT}/backup         Where backup files will be saved
-  -v <LOCAL_PATH>:/repo                ${CHE_MINI_PRODUCT_NAME} git repo to activate dev mode
-  -v <LOCAL_PATH>:/sync                Where remote ws files will be copied with sync command
-  -v <LOCAL_PATH>:/unison              Where unison profile for optimizing sync command resides
-
-COMMANDS:
-  action <action-name>                 Start action on ${CHE_MINI_PRODUCT_NAME} instance
-  backup                               Backups ${CHE_MINI_PRODUCT_NAME} configuration and data to ${CHE_CONTAINER_ROOT}/backup volume mount
-  config                               Generates a ${CHE_MINI_PRODUCT_NAME} config from vars; run on any start / restart
-  destroy                              Stops services, and deletes ${CHE_MINI_PRODUCT_NAME} instance data
-  download                             Pulls Docker images for the current ${CHE_MINI_PRODUCT_NAME} version
-  help                                 This message
-  info                                 Displays info about ${CHE_MINI_PRODUCT_NAME} and the CLI
-  init                                 Initializes a directory with a ${CHE_MINI_PRODUCT_NAME} install
-  offline                              Saves ${CHE_MINI_PRODUCT_NAME} Docker images into TAR files for offline install
-  restart                              Restart ${CHE_MINI_PRODUCT_NAME} services
-  restore                              Restores ${CHE_MINI_PRODUCT_NAME} configuration and data from ${CHE_CONTAINER_ROOT}/backup mount
-  rmi                                  Removes the Docker images for <version>, forcing a repull
-  ssh <wksp-name> [machine-name]       SSH to a workspace if SSH agent enabled
-  start                                Starts ${CHE_MINI_PRODUCT_NAME} services
-  stop                                 Stops ${CHE_MINI_PRODUCT_NAME} services
-  sync <wksp-name>                     Synchronize workspace with current working directory
-  test <test-name>                     Start test on ${CHE_MINI_PRODUCT_NAME} instance
-  upgrade                              Upgrades ${CHE_MINI_PRODUCT_NAME} from one version to another with migrations and backups
-  version                              Installed version and upgrade paths
-"
+pre_init() {
+  ADDITIONAL_MANDATORY_PARAMETERS=""
+  ADDITIONAL_OPTIONAL_DOCKER_PARAMETERS="
+  -e ARTIK_HOST=<YOUR_HOST>            IP address or hostname where artik will serve its users
+  -e ARTIK_PORT=<YOUR_PORT>            Port where che will bind itself to
+  -e ARTIK_CONTAINER=<YOUR_NAME>       Name for the che container"
+  ADDITIONAL_OPTIONAL_DOCKER_MOUNTS=""
+  ADDITIONAL_COMMANDS=""
+  ADDITIONAL_GLOBAL_OPTIONS=""
 }
 
 source /scripts/base/startup.sh

--- a/dockerfiles/server/entrypoint.sh
+++ b/dockerfiles/server/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2016 Samsung Electronics Co., Ltd.
 # All rights reserved. This program and the accompanying materials


### PR DESCRIPTION
### What does this PR do?
This PR adapts changes made to Eclipse Che to allow the inherited CLI to inherit its `usage()` statement from the core CLI so that as the base CLI makes improvements, the new CLI will have it inherited automatically.

Also provides a first implementation of a postflight check, which pulls the list of Swarm nodes from `artik.env` and then uses `curl` to ping each one's `/info` URL to see if it is reachable.

Must merge this at the same time as we merge: https://github.com/eclipse/che/pull/3940

### Changelog
Adapt CLI to changes in Eclipse Che #3940
Add postflight check of Swarm nodes as a test

### Release Notes
We are working to make sure Artik starts in any environment perfectly every time. We've added some additional preflight checks related to mandatory minimums for disk and memory available from the host. If the minimums are not enough to start at least one workspace, then Artik bootup will be interrupted. Preflight checks can now be skipped with either `--fast` or `--skip:preflight` on the command line.

We have also introduced postflight checks. We parse `artik.env` to get a list of Swarm nodes for your cluster. We then check that each is reachable using curl and that their `/info` URL is returning valid data. A failure of this command is an early indicator that firewalls were not configured correctly.  You can skip this check with `--fast` or `--skip:postflight`.
